### PR TITLE
Access functions

### DIFF
--- a/src/steinhardt/steinhardt.cpp
+++ b/src/steinhardt/steinhardt.cpp
@@ -900,15 +900,6 @@ Atom::Atom(){ }
 Atom::~Atom(){ }
 
 
-vector<double> Atom::gx(){ 
-    vector<double> pos;
-    pos.reserve(3);
-    pos.emplace_back(posx);
-    pos.emplace_back(posy);
-    pos.emplace_back(posz);
-    return pos; 
-}
-
 vector<int> Atom::gneighbors(){
     vector<int> nn;
     nn.reserve(n_neighbors);
@@ -918,20 +909,6 @@ vector<int> Atom::gneighbors(){
     return nn;
 }
 
-int Atom::gn_neighbors() { return n_neighbors; }
-int Atom::gfrenkelnumber() { return frenkelnumber; }
-int Atom::gissolid() { return issolid; }
-int Atom::gid() { return id; }
-int Atom::gbelongsto() { return belongsto; }
-int Atom::gstructure() { return structure; }
-void Atom::sx(vector<double> xx){
-    posx = xx[0];
-    posy = xx[1];
-    posz = xx[2];
-}
-
-void Atom::sid(int n){ id = n; }
-void Atom::sstructure(int n){ structure = n; }
 double Atom::gq(int qq){ return q[qq-2]; }
 void Atom::sq(int qq, double qval){ q[qq-2] = qval; }
 

--- a/src/steinhardt/steinhardt.h
+++ b/src/steinhardt/steinhardt.h
@@ -59,22 +59,13 @@ class Atom{
         //probably wont work
         //in that case will have to return a vector
         //its probably expensive
-        //but that doesnt matter because we wont use it regularly
-        vector<int> gneighbors();
-        int gn_neighbors();
-        int gfrenkelnumber();
-        int gissolid();
-        int gid();
-        int gbelongsto();
-        int gstructure();
-        void sx(vector<double>);
-        void sid(int);
-        void sstructure(int);
-        
+        //but that doesnt matter because we wont use it regularl
+      
         //function to set neighbors
         void sneighbors(vector<int> nns);
+        vector<int> gneighbors();
         void sneighborweights(vector<double> nns);
-
+        vector<double> gneighborweights(); 
 
         //variables for storing q2-12
         //invidual variables or arrays - individual ones are easier!
@@ -85,7 +76,6 @@ class Atom{
         double arealq[11][25];
         double aimgq[11][25];
         
-
         double gq(int);
         void sq(int, double);
         vector <vector<double>> gqlm(int);
@@ -98,7 +88,6 @@ class Atom{
         vector <double> custom;
         void scustom(vector <double>);
         vector<double> gcustom();
-        vector<double> gneighborweights(); 
 
 };
 

--- a/src/steinhardt/steinhardt_binding.cpp
+++ b/src/steinhardt/steinhardt_binding.cpp
@@ -14,23 +14,75 @@ PYBIND11_PLUGIN(steinhardt) {
 //bindings for Atom class
 //------------------------------------------------------------------
     py::module m("steinhardt");
-    py::class_<Atom>(m,"Atom")
-        .def(py::init< >())     
-        .def("gx",&Atom::gx,
-            R"doc(
-                Returns the coordinates of the atom.
+    py::class_<Atom>(m,"Atom",             
+        R"doc(
+            Class to hold the details of an atom. The various 
+            variables that can be accessed from python module
+            are mentioned in attributes.
 
-                Parameters
-                ----------
-                None
-                
-                Returns
-                -------
-                x : vector double
-                    position coordinates
-                )doc")
+            Attributes
+            ----------
+            Basic atom properties
+            ---------------------
+            x : float
+                x coordinate of atom
+            y : float
+                y coordinate of atom
+            z : float
+                z coordinate of atom
+            id : int
+                id of the atom
 
-        .def("gneighbors",&Atom::gneighbors,
+            Neighbor related properties
+            ---------------------------
+            n_neighbors : int
+                number of neighbors of the atom
+                Note that to access the list of neighbors, 
+                gneighbors() method needs to be used.
+            neighborweights : array like, float
+                The normalized weight of each neighbor atom contribution 
+                to calculation of q  parameters.
+            neighbordist : array like, float
+                List of neighbor distances to each atom.
+
+            Cluster related properties
+            --------------------------
+            frenkelnumber : int
+                frenkelnumber of the atom.
+            issolid : int
+                0 or 1. 1 if atom is solid.
+            structure : int
+                structure of the atom.
+            belongsto : int
+                id of the cluster to which atom belongs to.
+
+            Q value related properties
+            --------------------------
+            q : array like, float, length 11
+                array of q values.            
+            aq : array like, float, length 11
+                array of averaged q values.
+
+
+        )doc"
+        )
+        .def(py::init< >())
+        .def_readwrite("x", &Atom::posx)
+        .def_readwrite("y", &Atom::posy)
+        .def_readwrite("z", &Atom::posz)
+        .def_readwrite("n_neighbors", &Atom::n_neighbors)
+        .def_readwrite("neighborweights", &Atom::neighborweights)
+        .def_readwrite("neighbordist", &Atom::neighbordist)
+
+        .def_readwrite("frenkelnumber", &Atom::frenkelnumber)
+        .def_readwrite("issolid", &Atom::issolid)
+        .def_readwrite("structure", &Atom::structure)
+        .def_readwrite("belongsto", &Atom::belongsto)
+
+        .def_readwrite("q", &Atom::q)
+        .def_readwrite("aq", &Atom::aq)
+
+        .def("neighbors",&Atom::gneighbors,
             R"doc(
                 Returns the neighbors of the atom.
 
@@ -42,63 +94,6 @@ PYBIND11_PLUGIN(steinhardt) {
                 -------
                 x : vector int
                     neighbor indices
-                )doc")
-
-        .def("gn_neighbors",&Atom::gn_neighbors,
-            R"doc(
-                Returns the number of neighbors of the atom.
-
-                Parameters
-                ----------
-                None
-                
-                Returns
-                -------
-                n_neighbors : int 
-                    number of neighbors
-                )doc")
-
-        .def("gfrenkelnumber",&Atom::gfrenkelnumber,
-            R"doc(
-                Returns the frenkelnumber of the atom.
-
-                Parameters
-                ----------
-                None
-                
-                Returns
-                -------
-                frenkelnumber : int
-                    frenkelnumber
-                )doc")
-
-        .def("gissolid",&Atom::gissolid,
-            R"doc(
-                returns the solidity of an atom.
-
-                Parameters
-                ----------
-                None
-                
-                Returns
-                -------
-                issolid : int
-                    A value of 1 is returned if the atom is solid, 0 otherwise.
-                )doc")
-
-        .def("gstructure",&Atom::gstructure,
-            R"doc(
-                returns the structure of an atom.
-
-                Parameters
-                ----------
-                None
-                
-                Returns
-                -------
-                structure : int
-                    Int corresponding to the order of input structure histos.
-                    0 if structure is unknown.
                 )doc")
 
         .def("scustom",&Atom::scustom,
@@ -143,126 +138,6 @@ PYBIND11_PLUGIN(steinhardt) {
 
                 )doc")
 
-        .def("sneighborweights",&Atom::sneighborweights,
-            R"doc(
-                Set the weights of each neighbor towards the 
-                calculation of YLM. By default, the weight is
-                1 for each atom.
-
-                Parameters
-                ----------
-                array : weight of each atom, equal to number of neighbors
-                    of each atom.
-                
-                Returns
-                -------
-                None
-
-                )doc")
-
-
-        .def("gid",&Atom::gid,
-            R"doc(
-                Returns the id of the atom.
-
-                Parameters
-                ----------
-                None
-                
-                Returns
-                -------
-                id : int
-                    id of the atom
-                )doc")
-
-        .def("gbelongsto",&Atom::gbelongsto,
-            R"doc(
-                Returns the cluster id of the atom.
-
-                Parameters
-                ----------
-                None
-                
-                Returns
-                -------
-                id : int
-                    cluster id of the atom. A value of -1 means that the atom is liquid.
-                )doc")
-
-        .def("sx",&Atom::sx,
-            R"doc(
-                Set the coordinates of the atom.
-
-                Parameters
-                ----------
-                pos : vector double
-                    a vector containing x,y and z coordinates of the atom
-                
-                Returns
-                -------
-                None
-
-                )doc")
-
-        .def("sid",&Atom::sid,
-            R"doc(
-                sets the id of the atom.
-
-                Parameters
-                ----------
-                n : int
-                    id of the atom
-
-                Returns
-                -------
-                None.
-                )doc")
-
-        .def("sstructure",&Atom::sstructure,
-            R"doc(
-                sets the structure of the atom.
-
-                Parameters
-                ----------
-                n : int
-                    structure of the atom
-
-                Returns
-                -------
-                None.
-                )doc")
-
-        .def("gq",&Atom::gq,
-            R"doc(
-                get the qvalue of an atom.
-
-                Parameters
-                ----------
-                q : int
-                    number of the required q - from 2-12
-
-                Returns
-                -------
-                qval : double
-                    the corresponding qvalue.
-                )doc")
-
-        .def("sq",&Atom::sq,
-            R"doc(
-                sets the qvalue of an atom.
-
-                Parameters
-                ----------
-                q : int
-                    number of the required q - from 2-12
-                qval : double
-                    the corresponding qvalue.
-
-                Returns
-                -------
-                None.
-                )doc")
-
         .def("gqlm",&Atom::gqlm,
             R"doc(
                 get the real and imaginary qlm values of the atom.
@@ -279,36 +154,6 @@ PYBIND11_PLUGIN(steinhardt) {
                     second part is the 2q+1 imaginary values.
                 )doc")
 
-        .def("gaq",&Atom::gaq,
-            R"doc(
-                get the aqvalue of an atom.
-
-                Parameters
-                ----------
-                q : int
-                    number of the required q - from 2-12
-
-                Returns
-                -------
-                qval : double
-                    the corresponding qvalue.
-                )doc")
-
-        .def("saq",&Atom::saq,
-            R"doc(
-                sets the aqvalue of an atom.
-
-                Parameters
-                ----------
-                q : int
-                    number of the required q - from 2-12
-                qval : double
-                    the corresponding qvalue.
-
-                Returns
-                -------
-                None.
-                )doc")
 
         .def("gaqlm",&Atom::gaqlm,
             R"doc(
@@ -326,19 +171,6 @@ PYBIND11_PLUGIN(steinhardt) {
                     second part is the 2q+1 imaginary values.
                 )doc")
 
-        .def("gneighborweights",&Atom::gneighborweights,
-            R"doc(
-                get the neighbor weights of the atom.
-
-                Parameters
-                ----------
-                None
-
-                Returns
-                -------
-                qlms : 2D array of 2q+1 values
-                    Neighbor weights.
-                )doc")
     ; 
 
     //bindings and documentation for individual functions

--- a/src/steinhardt/steinhardt_binding.cpp
+++ b/src/steinhardt/steinhardt_binding.cpp
@@ -248,9 +248,60 @@ PYBIND11_PLUGIN(steinhardt) {
     ; 
 
     //bindings and documentation for individual functions
-    py::class_<System>(m,"System")
-        .def(py::init< >())
+    py::class_<System>(m,"System",R"doc(
+        Class to hold a steinhardt system. It includes all the atoms and
+        other system properties.
 
+        A list of variables that can be set directly is provided.
+
+        Attributes
+        ----------
+        File operations
+        ---------------
+        inputfile : string
+            Name of the input file to read the atom information
+        
+        Simulation box
+        --------------
+        nop : int
+            Number of atoms in the system.
+        minfrenkel : int
+            minimum number of frenkel connections to be identified as a 
+            solid.
+        boxx : float
+            x dimension of the box
+        boxy : float
+            y dimension of the box
+        boxz : float
+            z dimension of the box
+        neighbordistance : float
+            cutoff distance to be used for neighbor calculations.
+            accessible from python module as cutoff.
+
+        Calculation of largest cluster
+        ------------------------------
+        threshold : float
+            The cutoff value of connection between two atoms for them to be 
+            defined as having a bond.
+        avgthreshold : float
+            Averaged value of connection between an atom and its neighbors for 
+            an atom to be solid.
+        maxclusterid : int
+            id of the biggest cluster.
+
+        )doc")
+
+        .def(py::init< >())
+        .def_readwrite("inputfile", &System::inputfile)
+        .def_readwrite("nop", &System::nop)
+        .def_readwrite("minfrenkel", &System::minfrenkel)
+        .def_readwrite("boxx", &System::boxx)
+        .def_readwrite("boxy", &System::boxy)
+        .def_readwrite("boxz", &System::boxz)
+        .def_readwrite("cutoff", &System::neighbordistance)
+        .def_readwrite("threshold", &System::threshold)
+        .def_readwrite("avgthreshold", &System::avgthreshold)
+        .def_readwrite("maxclusterid", &System::maxclusterid)
         //minfrenkel function
         .def("set_nucsize_parameters",&System::set_nucsize_parameters,
             R"doc(
@@ -285,25 +336,6 @@ PYBIND11_PLUGIN(steinhardt) {
 
                 )doc")
         
-        .def("set_inputfile",&System::set_inputfile,
-            R"doc(
-                Set the inputfile for reading in for calculations. Currently, only a lammps
-                dump file can be used.
-
-                Parameters
-                ----------
-                inputfile : string
-                    filename of the file to be read
-
-                Returns
-                -------
-                None
-
-                See Also
-                --------
-                assign_particles - assign without reading a file
-
-                )doc")
 
         .def("assign_particles",&System::assign_particles,
             R"doc(
@@ -328,20 +360,6 @@ PYBIND11_PLUGIN(steinhardt) {
 
                 )doc")
 
-        .def("set_neighbordistance",&System::set_neighbordistance,
-            R"doc(
-                Set the cutoff distance for determining the neighbours of an atom.
-
-                Parameters
-                ----------
-                cutoff : double
-                    neighbor distance
-
-                Returns
-                -------
-                None
-                    )doc"
-            )
         .def("calculate_nucsize",&System::calculate_nucsize,
             R"doc(
                 Calculate the size of the largest cluster in the given system. Calculation
@@ -362,7 +380,8 @@ PYBIND11_PLUGIN(steinhardt) {
                     )doc"
             )
 
-        .def("gatom",&System::gatom,
+
+        .def("get_atom",&System::gatom,
             R"doc(
                 Access function that returns the Atom object at the queried position.
 
@@ -379,69 +398,7 @@ PYBIND11_PLUGIN(steinhardt) {
                     )doc"
             )
 
-        .def("gallatoms",&System::gallatoms,
-            R"doc(
-                Access function that returns the a vector of Atom objects.
-
-                Parameters
-                ----------
-                None
-
-                Returns
-                -------
-                allatoms : vctor of Atom objects
-                    all atoms in the system
-
-                    )doc"
-            )
-
-        .def("gbox",&System::gbox,
-            R"doc(
-                Access function that returns the dimensions of sim box.
-
-                Parameters
-                ----------
-                None
-
-                Returns
-                -------
-                boxdims : vector of box dimensions
-
-                    )doc"
-            )
-
-        .def("gboxdims",&System::gboxdims,
-            R"doc(
-                Access function that returns the low and high values of sim box.
-
-                Parametersb
-                ----------
-                None
-
-                Returns
-                -------
-                boxdims : vector of box dimensions
-
-                    )doc"
-            )
-
-        .def("gnop",&System::gnop,
-            R"doc(
-                Access function that returns the Atom object at the queried position.
-
-                Parameters
-                ----------
-                None
-
-                Returns
-                -------
-                nop : int
-                    number of atoms in the system.
-                    )doc"
-            )
-
-
-        .def("satom",&System::satom,
+       .def("set_atom",&System::satom,
             R"doc(
                 return the atom to its original location after modification.
 
@@ -458,26 +415,40 @@ PYBIND11_PLUGIN(steinhardt) {
             )
 
 
-        .def("glargestclusterid",&System::glargestclusterid,
+        .def("get_allatoms",&System::gallatoms,
             R"doc(
-                Access function that returns the id of largest cluster. This can be used in 
-                combination with gid() method of Atom to find if an atom belongs to the 
-                largest cluster. eg - if( atom.gbelongsto()==system.glargestclusterid() )
+                Access function that returns the a vector of Atom objects.
 
                 Parameters
                 ----------
                 None
-                
+
                 Returns
                 -------
-                cluster id  : int
-                    id of the largest cluster.
+                allatoms : vctor of Atom objects
+                    all atoms in the system
 
                     )doc"
             )
 
 
-        .def("gqvals",&System::gqvals,
+        .def("get_box",&System::gboxdims,
+            R"doc(
+                Access function that returns the low and high values of sim box.
+
+                Parametersb
+                ----------
+                None
+
+                Returns
+                -------
+                boxdims : vector of box dimensions
+
+                    )doc"
+            )
+
+
+        .def("get_qvals",&System::gqvals,
             R"doc(
                 return the required q values of all atoms.
 
@@ -495,7 +466,7 @@ PYBIND11_PLUGIN(steinhardt) {
             )
 
 
-        .def("gaqvals",&System::gaqvals,
+        .def("get_aqvals",&System::gaqvals,
             R"doc(
                 return the required aq values of all atoms.
 
@@ -513,7 +484,7 @@ PYBIND11_PLUGIN(steinhardt) {
             )
 
 
-        .def("read_particle_file",&System::read_particle_file,
+        .def("read_inputfile",&System::read_particle_file,
             R"doc(
                 Read a single snapshot of the lammps dump file and assign the positions
                 and ids to an array of Atom objects stored in the parent class.
@@ -529,7 +500,7 @@ PYBIND11_PLUGIN(steinhardt) {
                     )doc"
             )
 
-        .def("read_particle_instance",&System::read_particle_instance,
+        .def("read_particleinstance",&System::read_particle_instance,
             R"doc(
                 Read a single snapshot of the lammps dump file and assign the positions
                 and ids to an array of Atom objects stored in the parent class.
@@ -545,7 +516,7 @@ PYBIND11_PLUGIN(steinhardt) {
                     )doc"
             )
 
-        .def("get_abs_distance", (double (System::*) (Atom, Atom))  &System::get_abs_distance,
+        .def("get_absdistance", (double (System::*) (Atom, Atom))  &System::get_abs_distance,
             R"doc(
                 Get the distance between two atoms.
 
@@ -564,7 +535,7 @@ PYBIND11_PLUGIN(steinhardt) {
                     )doc"
             )
 
-        .def("get_all_neighbors", (void (System::*) (string &))  &System::get_all_neighbors, py::arg("method"), 
+        .def("get_allneighbors", (void (System::*) (string &))  &System::get_all_neighbors, py::arg("method"), 
             R"doc(
                 Find neighbors of all atoms in the system.
 
@@ -579,7 +550,7 @@ PYBIND11_PLUGIN(steinhardt) {
                     )doc"
             )
 
-        .def("get_all_neighbors", (void (System::*) ()) &System::get_all_neighbors,
+        .def("get_allneighbors", (void (System::*) ()) &System::get_all_neighbors,
             R"doc(
                 Find neighbors of all atoms in the system.
 
@@ -594,7 +565,7 @@ PYBIND11_PLUGIN(steinhardt) {
                     )doc"
             )
 
-        .def("calculate_complexQLM_6",&System::calculate_complexQLM_6,
+        .def("calculate_complexQLM6",&System::calculate_complexQLM_6,
             R"doc(
                 Find complex qlm 6 values for all atoms.
 
@@ -642,7 +613,7 @@ PYBIND11_PLUGIN(steinhardt) {
                     )doc"
             )
 
-        .def("set_reqd_qs",&System::set_reqd_qs,
+        .def("set_reqdqs",&System::set_reqd_qs,
             R"doc(
                 Set the list of qvalues to be calculated which will be done through 
                 calculate_q function.
@@ -679,7 +650,7 @@ PYBIND11_PLUGIN(steinhardt) {
                     )doc"
             )
 
-        .def("calculate_frenkel_numbers",&System::calculate_frenkel_numbers,
+        .def("calculate_frenkelnumbers",&System::calculate_frenkel_numbers,
             R"doc(
                 Find frenkel numbers of all atoms in the system.
 
@@ -709,7 +680,7 @@ PYBIND11_PLUGIN(steinhardt) {
                     )doc"
             )
 
-        .def("largest_cluster",&System::largest_cluster,
+        .def("find_largest_cluster",&System::largest_cluster,
             R"doc(
                 Find the largest in the system.
 

--- a/src/steinhardt/steinhardt_binding.cpp
+++ b/src/steinhardt/steinhardt_binding.cpp
@@ -39,11 +39,6 @@ PYBIND11_PLUGIN(steinhardt) {
                 number of neighbors of the atom
                 Note that to access the list of neighbors, 
                 gneighbors() method needs to be used.
-            neighborweights : array like, float
-                The normalized weight of each neighbor atom contribution 
-                to calculation of q  parameters.
-            neighbordist : array like, float
-                List of neighbor distances to each atom.
 
             Cluster related properties
             --------------------------
@@ -56,33 +51,20 @@ PYBIND11_PLUGIN(steinhardt) {
             belongsto : int
                 id of the cluster to which atom belongs to.
 
-            Q value related properties
-            --------------------------
-            q : array like, float, length 11
-                array of q values.            
-            aq : array like, float, length 11
-                array of averaged q values.
-
-
-        )doc"
+       )doc"
         )
         .def(py::init< >())
         .def_readwrite("x", &Atom::posx)
         .def_readwrite("y", &Atom::posy)
         .def_readwrite("z", &Atom::posz)
         .def_readwrite("n_neighbors", &Atom::n_neighbors)
-        .def_readwrite("neighborweights", &Atom::neighborweights)
-        .def_readwrite("neighbordist", &Atom::neighbordist)
-
         .def_readwrite("frenkelnumber", &Atom::frenkelnumber)
         .def_readwrite("issolid", &Atom::issolid)
         .def_readwrite("structure", &Atom::structure)
         .def_readwrite("belongsto", &Atom::belongsto)
 
-        .def_readwrite("q", &Atom::q)
-        .def_readwrite("aq", &Atom::aq)
 
-        .def("neighbors",&Atom::gneighbors,
+        .def("get_neighbors",&Atom::gneighbors,
             R"doc(
                 Returns the neighbors of the atom.
 
@@ -96,35 +78,7 @@ PYBIND11_PLUGIN(steinhardt) {
                     neighbor indices
                 )doc")
 
-        .def("scustom",&Atom::scustom,
-            R"doc(
-                Set custom values of an Atom
-
-                Parameters
-                ----------
-                vector double : list of custom values
-                
-                Returns
-                -------
-                None
-
-                )doc")
-
-        .def("gcustom",&Atom::gcustom,
-            R"doc(
-                returns the custom values of an atom.
-
-                Parameters
-                ----------
-                None
-                
-                Returns
-                -------
-                custom : vector double
-                    custom values of the atom.
-                )doc")
-
-        .def("sneighbors",&Atom::sneighbors,
+        .def("set_neighbors",&Atom::sneighbors,
             R"doc(
                 Set the neighbors of an atom
 
@@ -138,7 +92,127 @@ PYBIND11_PLUGIN(steinhardt) {
 
                 )doc")
 
-        .def("gqlm",&Atom::gqlm,
+        .def("get_neighborweights",&Atom::gneighborweights,
+            R"doc(
+                Returns the neighbor weights of the atom.
+
+                Parameters
+                ----------
+                None
+                
+                Returns
+                -------
+                x : vector float
+                    neighbor weights
+                )doc")
+
+        .def("set_neighborweights",&Atom::sneighborweights,
+            R"doc(
+                Set the neighbor weights of an atom
+
+                Parameters
+                ----------
+                array like float: weights of the neighbor atoms 
+                
+                Returns
+                -------
+                None
+
+                )doc")
+
+        .def("set_custom",&Atom::scustom,
+            R"doc(
+                Set custom values of an Atom
+
+                Parameters
+                ----------
+                vector double : list of custom values
+                
+                Returns
+                -------
+                None
+
+                )doc")
+
+        .def("get_custom",&Atom::gcustom,
+            R"doc(
+                returns the custom values of an atom.
+
+                Parameters
+                ----------
+                None
+                
+                Returns
+                -------
+                custom : vector double
+                    custom values of the atom.
+                )doc")
+
+        .def("get_q",&Atom::gq,
+            R"doc(
+                get  q value of the atom.
+
+                Parameters
+                ----------
+                q : int
+                    number of the required q - from 2-12
+
+                Returns
+                -------
+                q : float
+                    The queried q value
+                )doc")
+
+
+        .def("set_q",&Atom::sq,
+            R"doc(
+                set the q values of the atom.
+
+                Parameters
+                ----------
+                q : int
+                    number of the required q - from 2-12
+                d : double
+                    the q value to set
+
+                Returns
+                -------
+                None
+                )doc")
+
+        .def("get_aq",&Atom::gaq,
+            R"doc(
+                get  avg q value of the atom.
+
+                Parameters
+                ----------
+                q : int
+                    number of the required q - from 2-12
+
+                Returns
+                -------
+                q : float
+                    The queried q value
+                )doc")
+
+
+        .def("set_aq",&Atom::saq,
+            R"doc(
+                set the avg q values of the atom.
+
+                Parameters
+                ----------
+                q : int
+                    number of the required q - from 2-12
+                d : double
+                    the q value to set
+
+                Returns
+                -------
+                None
+                )doc")
+
+        .def("get_qlm",&Atom::gqlm,
             R"doc(
                 get the real and imaginary qlm values of the atom.
 
@@ -155,7 +229,7 @@ PYBIND11_PLUGIN(steinhardt) {
                 )doc")
 
 
-        .def("gaqlm",&Atom::gaqlm,
+        .def("get_aqlm",&Atom::gaqlm,
             R"doc(
                 get the real and imaginary aqlm values of the atom.
 


### PR DESCRIPTION
Streamlining of access functions. Remove unnecessary access functions and use use read_write from the pybind11 module.