### PR TITLE
Cell lists

### DIFF
--- a/src/pyscal/atom.cpp
+++ b/src/pyscal/atom.cpp
@@ -25,6 +25,7 @@ Atom::Atom( vector<double> pos, int idd, int typ){
     isneighborset = 0;
     n_neighbors = 0;
     lcluster = 0;
+    head = -1;
 
 
     for (int tn = 0; tn<MAXNUMBEROFNEIGHBORS; tn++){

--- a/src/pyscal/atom.h
+++ b/src/pyscal/atom.h
@@ -221,4 +221,7 @@ class Atom{
         vector<int> gchiparams();
         void schiparams(vector<int>);
 
+        //for cell list implementation
+        int head;
+
 };

--- a/src/pyscal/core.py
+++ b/src/pyscal/core.py
@@ -361,7 +361,7 @@ class System(pc.System):
 
 
     def find_neighbors(self, method='cutoff', cutoff=None, threshold=2, filter=None,
-                                            voroexp=1, padding=1.2, nlimit=6):
+                                            voroexp=1, padding=1.2, nlimit=6, cells=False):
         """
 
         Find neighbors of all atoms in the :class:`~pyscal.core.System`.
@@ -490,7 +490,10 @@ class System(pc.System):
             else:
                 #warnings.warn("THIS RAN")
                 self.set_neighbordistance(cutoff)
-                self.get_all_neighbors_normal()
+                if cells:
+                    self.get_all_neighbors_cells()
+                else:
+                    self.get_all_neighbors_normal()
 
         elif method == 'voronoi':
             self.voroexp = int(voroexp)

--- a/src/pyscal/core.py
+++ b/src/pyscal/core.py
@@ -361,7 +361,7 @@ class System(pc.System):
 
 
     def find_neighbors(self, method='cutoff', cutoff=None, threshold=2, filter=None,
-                                            voroexp=1, padding=1.2, nlimit=6, cells=False):
+                                            voroexp=1, padding=1.2, nlimit=6):
         """
 
         Find neighbors of all atoms in the :class:`~pyscal.core.System`.
@@ -490,7 +490,7 @@ class System(pc.System):
             else:
                 #warnings.warn("THIS RAN")
                 self.set_neighbordistance(cutoff)
-                if cells:
+                if len(self.atoms) > 2300:
                     self.get_all_neighbors_cells()
                 else:
                     self.get_all_neighbors_normal()

--- a/src/pyscal/system.h
+++ b/src/pyscal/system.h
@@ -153,6 +153,20 @@ class System{
         int gcriteria();
         void scriteria( int);
 
+        //for cell list implementation
+        struct cell{
+          int head = -1;
+        };
+        cell *cells;
+
+        int nx, ny, nz;
+        int total_cells;
+        int cell_index(int, int, int);
+        void set_up_cells();
+        vector<int> cell_periodic(int, int, int);
+        void get_all_neighbors_cells();
+
+        //we add the other functions as we go along
 
 
 };

--- a/src/pyscal/system_binding.cpp
+++ b/src/pyscal/system_binding.cpp
@@ -48,6 +48,7 @@ PYBIND11_MODULE(csystem, m) {
         .def("cget_aqvals",&System::gaqvals)
         .def("get_absdistance", (double (System::*) (Atom, Atom))  &System::get_abs_distance)
         .def("get_absdistance_vector", &System::get_distance_vector)
+        .def("get_all_neighbors_cells",&System::get_all_neighbors_cells)
         .def("get_all_neighbors_normal",&System::get_all_neighbors_normal)
         .def("get_all_neighbors_sann",&System::get_all_neighbors_sann)
         .def("get_all_neighbors_adaptive",&System::get_all_neighbors_adaptive)


### PR DESCRIPTION
Add cell lists to speed up the calculation. Cell lists show speed up for number of atoms greater than 2300, approximately. Cell lists are automatically chosen if number of atoms is greater than this number in core.py. At the moment cell lists are available for brute force cutoff method, and only for orthogonal simulation boxes. In a future work, this restriction can be eased with further testing.