### PR TITLE
Rdf normalisation fix

### DIFF
--- a/src/pyscal/core.py
+++ b/src/pyscal/core.py
@@ -305,7 +305,7 @@ class System(pc.System):
         boxvecs = self.box
         vol = np.dot(np.cross(boxvecs[0], boxvecs[1]), boxvecs[2])
         natoms = self.nop
-        rho = natoms/vol
+        rho = int(natoms*(natoms-1)*0.5)/vol
 
         shell_vols = (4./3.)*np.pi*((r+edgewidth)**3 - r**3)
         shell_rho = hist/shell_vols


### PR DESCRIPTION
Hi. In using pyscal i ran in to this discrepancy in my expectations and results it was giving.The way rdf was normalised would not give expected values for peak heights for simple tests with crystalline structures (i tested bcc using only pyscal functionality), or wouldn't reproduce the expectation that a LJ fluid rdf decays to 1 (tested as box of random points and a LJ fluid md simulation where i would load each frame in to pyscal and do the analysis). This is a shame since peak height contains useful information. The peak position is correct. 

The normalisation logic in your code and in general is just a ratio of shell density and bulk density. The code is histogramming pair distances, so the shell density calculated is not for N particles but n(n-1)/2 pair distances. I believe the detail missing is that the bulk density should not be N/V as previously but N(N-1)*0.5/V which is the bulk density relative to pair distances rather than particle number. This normalises the rdf to expected values and with correct peak heights.

Additional remark that i found out but wasn't obvious from the documentation to be is that, it is important for pyscal that all of the particle coordinates when initialising the system fit within the primary box. If I input coordinates that do not conform to this expectation, pyscal has some logic to deal with this. The pair distances that i would get from the in the distances = self.get_pairdistances() line would in this case be incorrect. The issue is solved if i wrap my system to fit the primary box before inputing it in to pyscal. 

Could be that that the. d = get_abs_distance(ti, tj, diffx, diffy, diffz); call is the source of the limitation. Smth like min_img_dist=np.remainder(s - t + box_half, box_dim) - box_half should work correctly in all cases. Hope this helps and is useful. Cheers