### PR TITLE
fixed the ase.py file so that the read_snap works

### DIFF
--- a/src/pyscal/formats/ase.py
+++ b/src/pyscal/formats/ase.py
@@ -1,6 +1,7 @@
 import numpy as np
 import gzip
 import pyscal.catom as pca
+from ase.io import read
 from ase import Atom, Atoms
 import gzip
 import io
@@ -23,6 +24,7 @@ def read_snap(aseobject, check_triclinic=False):
     #We have to process atoms and atomic objects from ase
     #Known issues lammps -dump modified format
     #first get box
+    aseobject = read(aseobject)
     a = np.array(aseobject.cell[0])
     b = np.array(aseobject.cell[1])
     c = np.array(aseobject.cell[2])

--- a/src/pyscal/formats/ase.py
+++ b/src/pyscal/formats/ase.py
@@ -8,14 +8,14 @@ import io
 import os
 
 #new function to wrap over ase objects
-def read_snap(aseobject, check_triclinic=False):
+def read_snap(filename, check_triclinic=False):
     """
     Function to read from a ASE atoms objects
 
     Parameters
     ----------
-    aseobject : ASE Atoms object
-        name of the ASE atoms object
+    filename : str
+	path of the ASE file
 
     triclinic : bool, optional
         True if the configuration is triclinic
@@ -24,7 +24,7 @@ def read_snap(aseobject, check_triclinic=False):
     #We have to process atoms and atomic objects from ase
     #Known issues lammps -dump modified format
     #first get box
-    aseobject = read(aseobject)
+    aseobject = read(filename)
     a = np.array(aseobject.cell[0])
     b = np.array(aseobject.cell[1])
     c = np.array(aseobject.cell[2])


### PR DESCRIPTION
I changed the read_snap function so that it takes in the filename and it gets the aseobject from it. Earlier it used to take the filename but the read_snap operates on aseobject which raises errors. 